### PR TITLE
Better handling of junk values with PARSE-INTEGER

### DIFF
--- a/src/hardware.lisp
+++ b/src/hardware.lisp
@@ -18,12 +18,18 @@
 
 (defun get-battery-charges (batteries)
   "Get the remaining battery charges for all the batteries on the system."
-  (mapcar (lambda (bat)
-            (parse-integer (get-result-from-system (concatenate 'string
-                                                                "cat "
-                                                                bat
-                                                                "/energy_now"))))
-          batteries))
+  (loop for bat in batteries
+        for energy_now = (get-result-from-system (concatenate 'string
+                                                              "cat "
+                                                              bat
+                                                              "/energy_now"))
+        for charge = (parse-integer energy_now :junk-allowed t)
+        if charge
+        collect charge into charges
+        else do (error 'expected-numeric-charge-value
+                       :battery bat
+                       :value energy_now)
+        finally (return charges)))
 
 (defun get-battery-capacities (batteries)
   "Get the total battery capacities for all the batteries on the system."

--- a/src/hardware.lisp
+++ b/src/hardware.lisp
@@ -3,6 +3,15 @@
 
 (in-package :hardware)
 
+(define-condition expected-numeric-charge-value (error)
+  ((battery :initarg :battery :initform nil :reader battery-read)
+   (value :initarg :value :initform nil :reader value-read))
+  (:documentation "This should be signalled with a failed attempt to use a charge value as an integer.")
+  (:report (lambda (condition stream)
+             (format stream "Failed attempt to use charge value ~A from battery ~S."
+                     (value-read condition)
+                     (battery-read condition)))))
+
 (defun get-batteries ()
   "Gets a list of batteries installed on the system."
   (get-list-from-system "find /sys/class/power_supply -name \"BAT*\""))


### PR DESCRIPTION
It's possible for `cat /sys/class/power_supply/BATnn/charge_now` to yield an empty string. See the syslog excerpt below. Signalling a condition when this is encountered provides a starting point for handling the issue. The calling routine should catch the error, invoke something like `(log-to-system (format nil "Junk value ~A for battery ~S" value bat))`, and then settle down until the issue is addressed.

    2024-12-23T09:08:29.595078-08:00 thomp3593 power-guard[1483870]: 3: (ERROR SB-INT:SIMPLE-PARSE-ERROR :FORMAT-CONTROL "no non-whitespace characters in string ~S." :FORMAT-ARGUMENTS (""))
    2024-12-23T09:08:29.595484-08:00 thomp3593 power-guard[1483870]: 4: (PARSE-INTEGER "" :START 0 :END NIL :RADIX 10 :JUNK-ALLOWED NIL)
    2024-12-23T09:08:29.595905-08:00 thomp3593 power-guard[1483870]: 5: (HARDWARE::GET-BATTERY-CHARGES ("/sys/class/power_supply/BAT0"))
    2024-12-23T09:08:29.595946-08:00 thomp3593 power-guard[1483870]: 6: (HARDWARE:GET-REMAINING-CHARGE)
    2024-12-23T09:08:29.596044-08:00 thomp3593 power-guard[1483870]: 7: (MAIN:MAIN)
    2024-12-23T09:08:29.596069-08:00 thomp3593 power-guard[1483870]: 8: ((FLET SB-UNIX::BODY :IN SB-IMPL::START-LISP))
    2024-12-23T09:08:29.596092-08:00 thomp3593 power-guard[1483870]: 9: ((FLET "WITHOUT-INTERRUPTS-BODY-1" :IN SB-IMPL::START-LISP))
    2024-12-23T09:08:29.596117-08:00 thomp3593 power-guard[1483870]: 10: (SB-IMPL::START-LISP)
    2024-12-23T09:08:29.596139-08:00 thomp3593 power-guard[1483870]: unhandled condition in --disable-debugger mode, quitting
    2024-12-23T09:08:29.598835-08:00 thomp3593 systemd[1]: power-guard.service: Main process exited, code=exited, status=1/FAILURE
    